### PR TITLE
Theme mockup: "Signal" — cybersec-forward take on the neuron backdrop

### DIFF
--- a/assets/css/extended/signal-01-vars.css
+++ b/assets/css/extended/signal-01-vars.css
@@ -1,0 +1,79 @@
+/* ============================================================================
+   SIGNAL — theme layer for WhiteMatterTech
+   ----------------------------------------------------------------------------
+   Keeps the white-matter idea (nodes, links, conveyed impulses) but reads it
+   through a security-operations lens: near-black canvas, hairline structure,
+   monospace telemetry, one signal colour doing all the talking.
+
+   Layered on top of PaperMod via assets/css/extended/*.css. The vendored theme
+   in themes/PaperMod is not modified, so this whole look reverts by deleting
+   the signal-*.css files and the two partial overrides.
+
+   ACCENT SWAP: every accent in the system derives from --wm-signal and
+   --wm-signal-2. Change those two lines to retheme the entire site.
+   ========================================================================== */
+
+:root {
+    /* --- surfaces ------------------------------------------------------- */
+    --wm-void: #06080c;
+    --wm-deep: #0a0e15;
+    --wm-panel: #0e131b;
+    --wm-panel-hi: #131a24;
+    --wm-line: #1c2531;
+    --wm-line-hi: #2a3648;
+
+    /* --- ink ------------------------------------------------------------ */
+    --wm-text: #c6d2e0;
+    --wm-head: #e8eef6;
+    --wm-dim: #78889c;
+    --wm-faint: #4a5768;
+
+    /* --- signal --------------------------------------------------------- */
+    --wm-signal: #35e0d0;   /* primary: links, focus, active, packets       */
+    --wm-signal-2: #67a2c9; /* heritage blue, carried over from the logo    */
+    --wm-warn: #ffb454;
+    --wm-crit: #ff5c78;
+
+    /* derived — do not hand-edit */
+    --wm-signal-dim: color-mix(in srgb, var(--wm-signal) 55%, transparent);
+    --wm-signal-ghost: color-mix(in srgb, var(--wm-signal) 14%, transparent);
+    --wm-signal-haze: color-mix(in srgb, var(--wm-signal) 7%, transparent);
+
+    /* --- type ----------------------------------------------------------- */
+    /* No webfont on purpose: an .onion mirror should not need a third-party
+       font request to render correctly. System mono is sharp everywhere. */
+    --wm-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+               "Liberation Mono", monospace;
+
+    /* --- geometry ------------------------------------------------------- */
+    --radius: 4px;
+    --wm-tick: 7px;
+}
+
+/* PaperMod is hard-pinned to dark here (defaultTheme: dark + toggle disabled),
+   so we re-point its own variables rather than fighting them selector-by-
+   selector. Everything the upstream theme styles inherits the new palette. */
+:root,
+.dark {
+    --theme: var(--wm-void);
+    --entry: var(--wm-panel);
+    --primary: var(--wm-head);
+    --secondary: var(--wm-dim);
+    --tertiary: var(--wm-line);
+    --content: var(--wm-text);
+    --code-block-bg: #080c12;
+    --code-bg: #121924;
+    --border: var(--wm-line);
+}
+
+/* The base colour lives on <html>, not <body>. The backdrop layers sit between
+   the two, and a painted <body> background would cover them on list pages. */
+html {
+    background-color: var(--wm-void);
+}
+
+body,
+.dark.list,
+.list {
+    background: transparent;
+}

--- a/assets/css/extended/signal-02-shell.css
+++ b/assets/css/extended/signal-02-shell.css
@@ -1,0 +1,314 @@
+/* ============================================================================
+   SIGNAL — shell: backdrop, header, nav, footer
+   ========================================================================== */
+
+body {
+    color: var(--wm-text);
+}
+
+/* --- backdrop --------------------------------------------------------------
+   The five fixed layers below all sit at z-index 0; document order stacks
+   them. Content is lifted to z-index 1. Nothing uses a negative z-index, so
+   the layers stay visible regardless of what paints a background on <body>.
+
+   Upstream put #particles-js at position:absolute with height:100%, which
+   resolves against the initial containing block — so the neuron field only
+   ever covered the first viewport and every page went flat below the fold.
+   Fixed positioning makes it a true backdrop and costs less to paint. */
+.wm-plate,
+#particles-js,
+.wm-grid,
+.wm-veil,
+.wm-scan {
+    position: fixed;
+    z-index: 0;
+}
+
+.wm-plate,
+.wm-grid,
+.wm-veil {
+    inset: 0;
+    pointer-events: none;
+}
+
+#particles-js {
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    background-image: none; /* the brain photo moves to its own layer below */
+}
+
+/* packet canvas, stacked on the particle canvas in the same coordinate space */
+#particles-js .wm-packets {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.header,
+.main,
+.footer {
+    position: relative;
+    z-index: 1;
+}
+
+/* Brain plate, re-cut as texture rather than photograph: knocked back hard and
+   tinted into the signal colour so it reads as neural structure, not stock. */
+.wm-plate {
+    background: url("/brain-dark.png") no-repeat 50% 42% / cover;
+    opacity: 0.8;
+    filter: grayscale(1) brightness(1.25) contrast(1.15)
+            sepia(1) hue-rotate(140deg) saturate(2);
+}
+
+/* Hairline survey grid — structure under the network, barely there. */
+.wm-grid {
+    background-image:
+        linear-gradient(to right, rgba(120, 170, 200, 0.055) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(120, 170, 200, 0.055) 1px, transparent 1px);
+    background-size: 64px 64px;
+    mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 30%, transparent 100%);
+    -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 30%, #000 30%, transparent 100%);
+}
+
+/* Vignette + colour grade over the whole stack, so content always wins. */
+.wm-veil {
+    background:
+        radial-gradient(ellipse 120% 80% at 50% -10%,
+            color-mix(in srgb, var(--wm-signal) 9%, transparent) 0%,
+            transparent 62%),
+        radial-gradient(ellipse 115% 105% at 50% 45%,
+            transparent 40%,
+            color-mix(in srgb, var(--wm-void) 88%, transparent) 100%);
+}
+
+/* Slow scan sweep. One element, one transform, GPU-cheap. */
+.wm-scan {
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 45vh;
+    pointer-events: none;
+    background: linear-gradient(to bottom,
+        transparent 0%,
+        color-mix(in srgb, var(--wm-signal) 3%, transparent) 60%,
+        color-mix(in srgb, var(--wm-signal) 7%, transparent) 92%,
+        color-mix(in srgb, var(--wm-signal) 22%, transparent) 99.4%,
+        transparent 100%);
+    animation: wm-sweep 14s linear infinite;
+}
+
+@keyframes wm-sweep {
+    0%   { transform: translate3d(0, -50vh, 0); opacity: 0; }
+    12%  { opacity: 1; }
+    88%  { opacity: 1; }
+    100% { transform: translate3d(0, 100vh, 0); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .wm-scan { display: none; }
+}
+
+/* --- header ---------------------------------------------------------------- */
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    background: color-mix(in srgb, var(--wm-void) 82%, transparent);
+    backdrop-filter: blur(14px) saturate(1.3);
+    -webkit-backdrop-filter: blur(14px) saturate(1.3);
+    border-bottom: 1px solid var(--wm-line);
+}
+
+/* the signal seam: a lit hairline that fades out at both edges */
+.header::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 1px;
+    background: linear-gradient(to right,
+        transparent, var(--wm-signal-dim) 22%, var(--wm-signal) 50%,
+        var(--wm-signal-dim) 78%, transparent);
+    opacity: 0.5;
+}
+
+.nav {
+    align-items: center;
+}
+
+/* --- logo ------------------------------------------------------------------ */
+.logo__mark {
+    color: var(--wm-signal);
+    text-shadow: 0 0 14px var(--wm-signal-dim);
+}
+
+.logo__text {
+    font-family: var(--wm-mono);
+    color: var(--wm-head);
+    letter-spacing: -0.01em;
+}
+
+.logo__cursor {
+    background: var(--wm-signal) !important;
+    box-shadow: 0 0 10px var(--wm-signal-dim);
+}
+
+/* --- nav ------------------------------------------------------------------- */
+#menu {
+    gap: 2px;
+}
+
+#menu li + li {
+    margin-inline-start: 0;
+}
+
+#menu a {
+    font-family: var(--wm-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.01em;
+    color: var(--wm-dim);
+    padding: 5px 10px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    transition: color 0.16s ease, background 0.16s ease, border-color 0.16s ease;
+}
+
+#menu a:hover {
+    color: var(--wm-head);
+    background: var(--wm-signal-haze);
+    border-color: var(--wm-signal-ghost);
+}
+
+/* upstream draws the active item with a full underline box; replace it with a
+   bracketed terminal-style marker that matches the ">#" logo */
+#menu .active {
+    font-weight: 500;
+    color: var(--wm-signal);
+    border-bottom: none !important;
+    margin-bottom: 0 !important;
+}
+
+#menu .active::before { content: "["; color: var(--wm-faint); margin-inline-end: 3px; }
+#menu .active::after  { content: "]"; color: var(--wm-faint); margin-inline-start: 3px; }
+
+/* --- telemetry rail --------------------------------------------------------
+   Small honest status line about how this site is served. Every claim here is
+   true of the deployment: TLS is enforced, the onion mirror is advertised via
+   Onion-Location, the feed is live, and the source is public. */
+.wm-rail {
+    position: relative;
+    z-index: 1;
+    max-width: calc(var(--nav-width) + var(--gap) * 2);
+    margin-inline: auto;
+    padding: 12px var(--gap) 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 18px;
+    font-family: var(--wm-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--wm-faint);
+}
+
+.wm-rail span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.wm-rail span::before {
+    content: "";
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--wm-signal);
+    box-shadow: 0 0 7px var(--wm-signal);
+}
+
+.wm-rail .wm-rail-idle::before {
+    background: var(--wm-faint);
+    box-shadow: none;
+}
+
+@media (max-width: 700px) {
+    .wm-rail { display: none; }
+}
+
+/* --- footer ---------------------------------------------------------------- */
+.footer {
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    color: var(--wm-faint);
+    border-top: 1px solid var(--wm-line);
+    margin-top: 48px;
+    padding-top: 20px;
+    background: linear-gradient(to bottom, transparent, var(--wm-deep));
+}
+
+.footer a {
+    color: var(--wm-dim);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--wm-line-hi);
+}
+
+.footer a:hover {
+    color: var(--wm-signal);
+    border-bottom-color: var(--wm-signal-dim);
+}
+
+.onion-note {
+    font-family: var(--wm-mono);
+    opacity: 1 !important;
+    font-size: 0.7rem !important;
+}
+
+.onion-note a {
+    color: var(--wm-faint);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--wm-line-hi);
+}
+
+.onion-note a::before {
+    content: "tor // ";
+    color: var(--wm-signal);
+    opacity: 0.7;
+}
+
+.onion-note a:hover {
+    color: var(--wm-signal);
+}
+
+.top-link {
+    background: var(--wm-panel-hi);
+    border: 1px solid var(--wm-line-hi);
+    color: var(--wm-signal);
+    border-radius: var(--radius);
+    backdrop-filter: blur(8px);
+}
+
+/* --- social icons ---------------------------------------------------------- */
+.social-icons a svg {
+    color: var(--wm-dim);
+    transition: color 0.16s ease, transform 0.16s ease;
+}
+
+.social-icons a:hover svg {
+    color: var(--wm-signal);
+    transform: translateY(-2px);
+}
+
+/* --- scrollbar ------------------------------------------------------------- */
+::-webkit-scrollbar-track { background: var(--wm-void); }
+::-webkit-scrollbar-thumb { background: var(--wm-line-hi); border-radius: 0; }
+::-webkit-scrollbar-thumb:hover { background: var(--wm-signal-dim); }
+
+::selection {
+    background: var(--wm-signal-dim);
+    color: var(--wm-void);
+}

--- a/assets/css/extended/signal-02-shell.css
+++ b/assets/css/extended/signal-02-shell.css
@@ -204,22 +204,30 @@ body {
     z-index: 1;
     max-width: calc(var(--nav-width) + var(--gap) * 2);
     margin-inline: auto;
-    padding: 12px var(--gap) 4px;
+    padding: 12px var(--gap) 6px;
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 18px;
+    gap: 6px 10px;
     font-family: var(--wm-mono);
-    font-size: 0.66rem;
+    font-size: 0.7rem;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--wm-faint);
 }
 
+/* Each item carries its own surface. The plate behind the rail is at its
+   brightest right here, and unbacked text at this size disappears into it. */
 .wm-rail span {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 7px;
     white-space: nowrap;
+    padding: 3px 9px;
+    border-radius: 3px;
+    color: var(--wm-dim);
+    background: color-mix(in srgb, var(--wm-void) 62%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    text-shadow: 0 1px 4px var(--wm-void);
 }
 
 .wm-rail span::before {

--- a/assets/css/extended/signal-03-content.css
+++ b/assets/css/extended/signal-03-content.css
@@ -1,0 +1,536 @@
+/* ============================================================================
+   SIGNAL — content: hero, entries, post pages, taxonomy, code
+   ========================================================================== */
+
+/* --- shared panel treatment ------------------------------------------------
+   Every card is a node on the board: hairline box, dark fill, an accent rail
+   on the leading edge that lights when you address it, and HUD corner ticks. */
+.post-entry,
+.first-entry,
+.home-info,
+.tag-entry,
+.paginav,
+#searchResults .post-entry {
+    position: relative;
+    background: color-mix(in srgb, var(--wm-panel) 88%, transparent);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    box-shadow: none;
+    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post-entry::before {
+    content: "";
+    position: absolute;
+    inset-block: -1px;
+    inset-inline-start: -1px;
+    width: 2px;
+    border-radius: var(--radius) 0 0 var(--radius);
+    background: var(--wm-line-hi);
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* corner ticks, drawn with a single conic-free border trick on ::after */
+.post-entry::after {
+    content: "";
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    width: var(--wm-tick);
+    height: var(--wm-tick);
+    border-top: 1px solid var(--wm-line-hi);
+    border-right: 1px solid var(--wm-line-hi);
+    transition: border-color 0.2s ease;
+}
+
+.post-entry:hover,
+.tag-entry:hover {
+    border-color: var(--wm-signal-ghost);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 30px -18px var(--wm-signal),
+                0 0 0 1px var(--wm-signal-haze);
+}
+
+.post-entry:hover::before {
+    background: var(--wm-signal);
+    box-shadow: 0 0 12px var(--wm-signal-dim);
+}
+
+.post-entry:hover::after {
+    border-color: var(--wm-signal);
+}
+
+.post-entry:hover .entry-header h2 {
+    color: var(--wm-head);
+}
+
+/* --- home hero ------------------------------------------------------------- */
+.home-info {
+    text-align: center;
+    padding: 40px var(--gap) 32px;
+    overflow: hidden;
+}
+
+.home-info img[src*="profile"] {
+    border-radius: 50%;
+    border: 1px solid var(--wm-line-hi);
+    padding: 3px;
+    background: var(--wm-void);
+    box-shadow: 0 0 0 1px var(--wm-signal-ghost),
+                0 0 42px -6px var(--wm-signal-dim);
+}
+
+.home-info .entry-header h1 {
+    font-size: 2.35rem;
+    letter-spacing: -0.025em;
+    margin: 18px 0 6px;
+    color: var(--wm-head);
+}
+
+/* kicker above the name, in the same register as the logo */
+.home-info .entry-header::before {
+    content: "// node: whitematter.tech";
+    display: block;
+    font-family: var(--wm-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--wm-signal);
+    opacity: 0.75;
+    margin-top: 14px;
+}
+
+.home-info > .entry-content {
+    font-family: var(--wm-mono);
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
+    color: var(--wm-dim);
+}
+
+.home-info .entry-footer {
+    margin-top: 4px;
+}
+
+/* the white-matter definition, framed as a spec block rather than a paragraph */
+.home-info > section.entry-content {
+    font-family: inherit;
+    position: relative;
+    max-width: 62ch;
+    margin: 26px auto 4px;
+    padding: 16px 20px;
+    text-align: start;
+    font-size: 0.95rem;
+    line-height: 1.62;
+    color: var(--wm-text);
+    background: color-mix(in srgb, var(--wm-signal) 3%, transparent);
+    border: 1px solid var(--wm-line);
+    border-inline-start: 2px solid var(--wm-signal);
+    border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.home-info > section.entry-content b {
+    color: var(--wm-signal);
+    font-weight: 600;
+}
+
+/* --- list entries ---------------------------------------------------------- */
+.post-entry {
+    padding: 22px 24px;
+}
+
+.entry-header h2 {
+    font-size: 1.35rem;
+    line-height: 1.28;
+    letter-spacing: -0.015em;
+    color: var(--wm-head);
+    transition: color 0.16s ease;
+}
+
+.entry-content {
+    color: var(--wm-dim);
+    font-size: 0.92rem;
+    line-height: 1.6;
+    margin: 10px 0;
+}
+
+.entry-footer,
+.post-meta,
+.archive-meta,
+.breadcrumbs,
+.archive-count,
+.pagination a {
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    color: var(--wm-faint);
+}
+
+.entry-cover {
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--wm-line);
+}
+
+.entry-cover img {
+    display: block;
+    filter: saturate(0.85) contrast(1.05);
+}
+
+/* --- post page -------------------------------------------------------------
+   Long-form reading gets its own surface. The backdrop is deliberately busy
+   on this site, and body copy should never have to compete with it. */
+.post-single {
+    position: relative;
+    margin-top: 22px;
+    padding: 10px 34px 34px;
+    background: color-mix(in srgb, var(--wm-panel) 93%, transparent);
+    backdrop-filter: blur(12px) saturate(1.1);
+    -webkit-backdrop-filter: blur(12px) saturate(1.1);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+}
+
+@media (max-width: 640px) {
+    .post-single { padding: 6px 18px 24px; }
+}
+
+.page-header {
+    position: relative;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--wm-line);
+}
+
+.page-header h1 {
+    letter-spacing: -0.02em;
+}
+
+.page-header h1::before {
+    content: "// ";
+    font-family: var(--wm-mono);
+    font-size: 0.7em;
+    color: var(--wm-signal);
+    opacity: 0.8;
+}
+
+.breadcrumbs a {
+    color: var(--wm-faint);
+    text-decoration: none;
+}
+
+.breadcrumbs a:hover { color: var(--wm-signal); }
+
+.post-header {
+    position: relative;
+    margin: 26px auto var(--content-gap);
+}
+
+/* mono kicker rule above every post title */
+.post-header::before {
+    content: "";
+    display: block;
+    width: 34px;
+    height: 2px;
+    margin-bottom: 16px;
+    background: var(--wm-signal);
+    box-shadow: 0 0 12px var(--wm-signal-dim);
+}
+
+.post-title {
+    font-size: 2.15rem;
+    line-height: 1.16;
+    letter-spacing: -0.028em;
+    color: var(--wm-head);
+    margin-bottom: 10px;
+}
+
+.post-content {
+    color: var(--wm-text);
+    line-height: 1.72;
+}
+
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4 {
+    color: var(--wm-head);
+    letter-spacing: -0.015em;
+}
+
+/* markdown-level heading markers in the gutter — the ">#" motif again, and a
+   quiet visual outline of the page. Only where there is room for it. */
+@media (min-width: 1180px) {
+    .post-content h2,
+    .post-content h3 {
+        position: relative;
+    }
+
+    .post-content h2::before,
+    .post-content h3::before {
+        position: absolute;
+        inset-inline-end: calc(100% + 14px);
+        white-space: nowrap;
+        font-family: var(--wm-mono);
+        font-weight: 400;
+        font-size: 0.9em;
+        color: var(--wm-signal);
+        opacity: 0.32;
+        line-height: inherit;
+    }
+
+    .post-content h2::before { content: "##"; }
+    .post-content h3::before { content: "###"; }
+}
+
+.post-content a {
+    color: var(--wm-signal);
+    box-shadow: none;
+    text-decoration: none;
+    border-bottom: 1px dotted var(--wm-signal-dim);
+    transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.post-content a:hover {
+    border-bottom: 1px solid var(--wm-signal);
+    background: var(--wm-signal-haze);
+}
+
+.post-content blockquote {
+    border-inline-start: 2px solid var(--wm-signal);
+    background: color-mix(in srgb, var(--wm-signal) 4%, transparent);
+    padding: 12px 18px;
+    border-radius: 0 var(--radius) var(--radius) 0;
+    color: var(--wm-text);
+    font-style: normal;
+}
+
+.post-content img {
+    border-radius: var(--radius);
+    border: 1px solid var(--wm-line);
+}
+
+.post-content table th {
+    font-family: var(--wm-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--wm-dim);
+    border-bottom: 1px solid var(--wm-line-hi);
+}
+
+.post-content hr {
+    border: 0;
+    height: 1px;
+    background: linear-gradient(to right,
+        var(--wm-signal-ghost), var(--wm-line), transparent);
+}
+
+/* --- code ------------------------------------------------------------------
+   Terminal chrome: a labelled bar with a prompt glyph instead of the usual
+   three fake traffic-light dots. */
+.post-content div.highlight,
+.post-content pre {
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+}
+
+.post-content div.highlight {
+    padding-top: 30px;
+    background: var(--code-block-bg);
+}
+
+.post-content div.highlight::before {
+    content: "$";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 28px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    color: var(--wm-signal);
+    background: var(--wm-panel);
+    border-bottom: 1px solid var(--wm-line);
+    border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.post-content div.highlight pre {
+    border: 0;
+    border-radius: 0;
+    margin: 0;
+}
+
+.post-content .copy-code {
+    top: 3px;
+    right: 4px;
+    font-family: var(--wm-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--wm-faint);
+    background: transparent;
+    opacity: 1;
+}
+
+.post-content .copy-code:hover { color: var(--wm-signal); }
+
+.post-content code:not(.post-content div.highlight code) {
+    font-family: var(--wm-mono);
+    color: var(--wm-signal-2);
+    background: var(--code-bg);
+    border: 1px solid var(--wm-line);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 0.86em;
+}
+
+/* --- toc ------------------------------------------------------------------- */
+.toc {
+    background: color-mix(in srgb, var(--wm-panel) 86%, transparent);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    backdrop-filter: blur(6px);
+}
+
+.toc details summary {
+    font-family: var(--wm-mono);
+    font-size: 0.76rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--wm-dim);
+    cursor: pointer;
+}
+
+.toc .inner a {
+    color: var(--wm-dim);
+    text-decoration: none;
+}
+
+.toc .inner a:hover { color: var(--wm-signal); }
+
+/* --- tags ------------------------------------------------------------------
+   Bracketed mono chips, read like labels on a case file rather than pills. */
+.post-tags li a,
+.terms-tags a {
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    color: var(--wm-dim);
+    /* the backdrop shows through the taxonomy pages, so chips carry their own
+       surface — otherwise labels land on top of bright plate strands */
+    background: color-mix(in srgb, var(--wm-panel) 78%, transparent);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    border: 1px solid var(--wm-line-hi);
+    border-radius: 3px;
+    padding: 3px 9px;
+    box-shadow: none;
+    transition: color 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+}
+
+.post-tags li a::before,
+.terms-tags a::before {
+    content: "#";
+    color: var(--wm-faint);
+    margin-inline-end: 2px;
+}
+
+.post-tags li a:hover,
+.terms-tags a:hover {
+    color: var(--wm-signal);
+    border-color: var(--wm-signal-dim);
+    background: var(--wm-signal-haze);
+}
+
+/* the two tags that are the site's spine get the hot treatment */
+.post-tags li a[href*="cybersecurity"],
+.post-tags li a[href*="security"],
+.terms-tags a[href*="cybersecurity"],
+.terms-tags a[href*="security"] {
+    color: var(--wm-crit);
+    border-color: color-mix(in srgb, var(--wm-crit) 35%, transparent);
+}
+
+.post-tags li a[href*="cybersecurity"]:hover,
+.post-tags li a[href*="security"]:hover,
+.terms-tags a[href*="cybersecurity"]:hover,
+.terms-tags a[href*="security"]:hover {
+    background: color-mix(in srgb, var(--wm-crit) 10%, transparent);
+    border-color: var(--wm-crit);
+}
+
+/* --- pagination / paginav --------------------------------------------------- */
+.pagination a,
+.paginav a {
+    font-family: var(--wm-mono);
+    color: var(--wm-dim);
+    background: var(--wm-panel);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+}
+
+.pagination a:hover,
+.paginav a:hover {
+    color: var(--wm-signal);
+    border-color: var(--wm-signal-dim);
+}
+
+.paginav { border: 0; }
+.paginav .title {
+    font-family: var(--wm-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    color: var(--wm-faint);
+}
+
+/* --- search ---------------------------------------------------------------- */
+#searchbox input {
+    font-family: var(--wm-mono);
+    background: var(--wm-panel);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    color: var(--wm-text);
+    padding: 12px 14px;
+}
+
+#searchbox input:focus {
+    outline: none;
+    border-color: var(--wm-signal-dim);
+    box-shadow: 0 0 0 3px var(--wm-signal-haze);
+}
+
+#searchResults li:active,
+#searchResults li:focus,
+#searchResults li:hover {
+    background: var(--wm-signal-haze);
+}
+
+/* --- archive / terms -------------------------------------------------------- */
+.archive-year,
+.archive-month {
+    border-bottom: 1px solid var(--wm-line);
+}
+
+.archive-month-header,
+.archive-year-header {
+    font-family: var(--wm-mono);
+}
+
+.archive-entry-title { color: var(--wm-text); }
+.archive-entry:hover .archive-entry-title { color: var(--wm-signal); }
+
+.tag-entry { padding: 16px 18px; }
+.tag-entry .entry-header h2 { font-size: 1.05rem; }
+
+/* --- focus ring (keyboard) --------------------------------------------------- */
+a:focus-visible,
+button:focus-visible,
+summary:focus-visible {
+    outline: 2px solid var(--wm-signal);
+    outline-offset: 2px;
+    border-radius: 2px;
+}

--- a/assets/css/extended/signal-04-gist.css
+++ b/assets/css/extended/signal-04-gist.css
@@ -1,0 +1,83 @@
+/* ============================================================================
+   SIGNAL — embedded GitHub gists
+   ----------------------------------------------------------------------------
+   The gist shortcode injects GitHub's embed script, which writes its markup
+   straight into the document and pulls in a light-mode stylesheet. On a dark
+   site that leaves a white slab in the middle of long posts — several of the
+   homelab write-ups are mostly gist.
+
+   The embed is same-document (not an iframe), so it can simply be restyled.
+   GitHub's rules are two classes deep; scoping through .post-content wins on
+   specificity without needing !important, and without touching the shortcode.
+   ========================================================================== */
+
+.post-content .gist {
+    margin: var(--content-gap) 0;
+}
+
+.post-content .gist .gist-file {
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-bottom: 0;
+}
+
+.post-content .gist .gist-data {
+    background-color: var(--code-block-bg);
+    border-bottom: 1px solid var(--wm-line);
+}
+
+.post-content .gist .highlight,
+.post-content .gist .blob-wrapper {
+    background-color: var(--code-block-bg);
+}
+
+.post-content .gist .blob-num {
+    color: var(--wm-faint);
+    background-color: transparent;
+    border-color: var(--wm-line);
+}
+
+.post-content .gist .blob-code,
+.post-content .gist .blob-code-inner {
+    color: var(--wm-text);
+    background-color: transparent;
+}
+
+.post-content .gist tr:nth-child(even) .blob-code,
+.post-content .gist tr:nth-child(even) .blob-num {
+    background-color: transparent;
+}
+
+/* footer bar: "hosted with ♥ by GitHub / view raw" */
+.post-content .gist .gist-meta {
+    background-color: var(--wm-panel);
+    color: var(--wm-dim);
+    border-top: 0;
+    font-family: var(--wm-mono);
+    font-size: 0.7rem;
+}
+
+.post-content .gist .gist-meta a {
+    color: var(--wm-signal);
+    border-bottom: 0;
+}
+
+/* --- syntax tokens ---------------------------------------------------------
+   GitHub's primer prefixes. Mapped onto the signal palette so gists read the
+   same as Hugo-highlighted blocks rather than as a foreign object. */
+.post-content .gist .pl-c,
+.post-content .gist .pl-c span { color: var(--wm-faint); font-style: italic; }
+
+.post-content .gist .pl-k        { color: #ff7ba8; }
+.post-content .gist .pl-s,
+.post-content .gist .pl-pds,
+.post-content .gist .pl-s .pl-pse .pl-s1 { color: var(--wm-signal); }
+.post-content .gist .pl-c1,
+.post-content .gist .pl-s .pl-v  { color: var(--wm-warn); }
+.post-content .gist .pl-en,
+.post-content .gist .pl-e        { color: var(--wm-signal-2); }
+.post-content .gist .pl-v,
+.post-content .gist .pl-smi,
+.post-content .gist .pl-vpf      { color: var(--wm-text); }
+.post-content .gist .pl-ent      { color: #9ae08a; }

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -10,6 +10,10 @@
        live in the theme's own extend_footer partial, but this project-level partial
        overrides that one wholesale, so they were dropped when the onion note was
        added. Re-include them here, with root-absolute paths (relURL) so the
-       animation loads on every page and not only the homepage. */ -}}
+       animation loads on every page and not only the homepage.
+
+       particles-signal.js supersedes the old particles.js config: recoloured to
+       the signal palette, honours prefers-reduced-motion, adds the packet layer,
+       and drops the stats.js FPS counter that threw on every page load. */ -}}
 <script src="{{ "js/particles.min.js" | relURL }}" defer></script>
-<script src="{{ "js/particles.js" | relURL }}" defer></script>
+<script src="{{ "js/particles-signal.js" | relURL }}" defer></script>

--- a/layouts/partials/particles.html
+++ b/layouts/partials/particles.html
@@ -1,0 +1,26 @@
+{{- /* SIGNAL backdrop stack. Overrides the theme partial of the same name.
+
+       Two fixes carried in here on top of the new layers:
+         1. the theme's version opened <div class="site-wrapper"> and never
+            closed it, leaving the browser to auto-repair the document;
+         2. #particles-js was absolutely positioned, so the network stopped at
+            the first viewport. It is fixed now (see signal-02-shell.css).
+
+       Order matters — these are all z-index:0 and stack by document order:
+       plate (texture) → grid (structure) → particles (the network) →
+       veil (grade) → scan (sweep). */ -}}
+<div class="wm-plate" aria-hidden="true"></div>
+<div class="wm-grid" aria-hidden="true"></div>
+<div id="particles-js"></div>
+<div class="wm-veil" aria-hidden="true"></div>
+<div class="wm-scan" aria-hidden="true"></div>
+
+{{- /* Telemetry rail: how this page is actually served. Every claim is true of
+       the deployment — TLS at the edge, an advertised onion mirror, a live
+       feed, and a public source tree. */ -}}
+<div class="wm-rail" aria-hidden="true">
+  <span>tls: enforced</span>
+  <span>onion: advertised</span>
+  <span>feed: live</span>
+  <span>source: public</span>
+</div>

--- a/static/js/particles-signal.js
+++ b/static/js/particles-signal.js
@@ -1,0 +1,268 @@
+/* ============================================================================
+   SIGNAL — particle network
+   ----------------------------------------------------------------------------
+   Same white-matter idea as before: nodes, and links between nodes. What is
+   added is the thing white matter actually does — conveying impulses. Packets
+   travel the links, and the node they land on pings. Read as neurons or read
+   as traffic on a monitored network; it is deliberately both.
+
+   Replaces static/js/particles.js, which also carried a stats.js FPS counter
+   copied from the original CodePen. stats.js was never loaded on this site, so
+   every page threw "Uncaught ReferenceError: Stats is not defined". Gone.
+   ========================================================================== */
+
+(function () {
+    "use strict";
+
+    var SIGNAL = "#35e0d0";
+    var SIGNAL_2 = "#67a2c9";
+    var CRIT = "#ff5c78";
+
+    var reduceMotion = window.matchMedia &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    particlesJS("particles-js", {
+        particles: {
+            number: { value: 38, density: { enable: true, value_area: 900 } },
+            color: { value: [SIGNAL, SIGNAL_2, "#ffffff"] },
+            shape: {
+                type: "circle",
+                stroke: { width: 0, color: "#000000" },
+                polygon: { nb_sides: 5 }
+            },
+            opacity: {
+                value: 0.55,
+                random: true,
+                anim: {
+                    enable: !reduceMotion,
+                    speed: 0.5,
+                    opacity_min: 0.08,
+                    sync: false
+                }
+            },
+            size: {
+                value: 2.4,
+                random: true,
+                anim: {
+                    enable: !reduceMotion,
+                    speed: 0.7,
+                    size_min: 0.3,
+                    sync: false
+                }
+            },
+            line_linked: {
+                enable: true,
+                distance: 155,
+                color: SIGNAL,
+                opacity: 0.24,
+                width: 1
+            },
+            move: {
+                enable: !reduceMotion,
+                speed: 0.7,
+                direction: "none",
+                random: false,
+                straight: false,
+                out_mode: "out",
+                bounce: false,
+                attract: { enable: true, rotateX: 900, rotateY: 1400 }
+            }
+        },
+        interactivity: {
+            detect_on: "canvas",
+            events: {
+                onhover: { enable: !reduceMotion, mode: "grab" },
+                onclick: { enable: !reduceMotion, mode: "push" },
+                resize: true
+            },
+            modes: {
+                grab: { distance: 210, line_linked: { opacity: 0.6 } },
+                push: { particles_nb: 3 },
+                repulse: { distance: 200, duration: 0.4 },
+                remove: { particles_nb: 2 }
+            }
+        },
+        retina_detect: true
+    });
+
+    if (reduceMotion) return;
+
+    /* --- packet layer ------------------------------------------------------
+       A second canvas over the particle canvas, sharing its coordinate space
+       so packet positions can be read straight off the live particle array
+       (nodes keep drifting while a packet is in flight, and the packet should
+       track them). */
+
+    function start(attempt) {
+        var dom = window.pJSDom && window.pJSDom[0];
+        if (!dom || !dom.pJS || !dom.pJS.particles.array.length) {
+            if (attempt > 40) return;
+            return window.setTimeout(function () { start(attempt + 1); }, 120);
+        }
+
+        var pJS = dom.pJS;
+        var host = document.getElementById("particles-js");
+        var source = pJS.canvas.el;
+        if (!host || !source) return;
+
+        var canvas = document.createElement("canvas");
+        canvas.className = "wm-packets";
+        canvas.setAttribute("aria-hidden", "true");
+        host.appendChild(canvas);
+        var ctx = canvas.getContext("2d");
+
+        function sync() {
+            canvas.width = source.width;
+            canvas.height = source.height;
+        }
+        sync();
+
+        var resizeTimer;
+        window.addEventListener("resize", function () {
+            window.clearTimeout(resizeTimer);
+            resizeTimer = window.setTimeout(sync, 250);
+        });
+
+        var ratio = pJS.canvas.pxratio || 1;
+        var packets = [];
+        var pings = [];
+        var MAX_PACKETS = 6;
+        var SPAWN_MS = 620;
+        var sinceSpawn = 0;
+        var lastFrame = 0;
+
+        function linkRange() {
+            /* particles.js pre-scales line_linked.distance by the pixel ratio
+               during retina init, so this is already in canvas units. */
+            return pJS.particles.line_linked.distance;
+        }
+
+        function spawn() {
+            var nodes = pJS.particles.array;
+            if (nodes.length < 2 || packets.length >= MAX_PACKETS) return;
+
+            var from = nodes[(Math.random() * nodes.length) | 0];
+            var range = linkRange();
+            var reachable = [];
+
+            for (var i = 0; i < nodes.length; i++) {
+                var node = nodes[i];
+                if (node === from) continue;
+                var dx = from.x - node.x;
+                var dy = from.y - node.y;
+                if (dx * dx + dy * dy < range * range) reachable.push(node);
+            }
+            if (!reachable.length) return;
+
+            var critical = Math.random() < 0.11;
+            packets.push({
+                from: from,
+                to: reachable[(Math.random() * reachable.length) | 0],
+                progress: 0,
+                duration: 780 + Math.random() * 640,
+                critical: critical,
+                color: critical ? CRIT
+                     : (Math.random() < 0.35 ? SIGNAL_2 : SIGNAL)
+            });
+        }
+
+        function drawPacket(p) {
+            /* fade in and out so packets never pop at either endpoint */
+            var life = Math.sin(Math.PI * p.progress);
+            var hx = p.from.x + (p.to.x - p.from.x) * p.progress;
+            var hy = p.from.y + (p.to.y - p.from.y) * p.progress;
+            var tailAt = Math.max(0, p.progress - 0.22);
+            var tx = p.from.x + (p.to.x - p.from.x) * tailAt;
+            var ty = p.from.y + (p.to.y - p.from.y) * tailAt;
+
+            /* the link itself, lit for as long as it carries something */
+            ctx.globalAlpha = 0.16 * life;
+            ctx.strokeStyle = p.color;
+            ctx.lineWidth = 1 * ratio;
+            ctx.beginPath();
+            ctx.moveTo(p.from.x, p.from.y);
+            ctx.lineTo(p.to.x, p.to.y);
+            ctx.stroke();
+
+            /* trail */
+            var trail = ctx.createLinearGradient(tx, ty, hx, hy);
+            trail.addColorStop(0, "transparent");
+            trail.addColorStop(1, p.color);
+            ctx.globalAlpha = 0.75 * life;
+            ctx.strokeStyle = trail;
+            ctx.lineWidth = 1.5 * ratio;
+            ctx.lineCap = "round";
+            ctx.beginPath();
+            ctx.moveTo(tx, ty);
+            ctx.lineTo(hx, hy);
+            ctx.stroke();
+
+            /* head */
+            ctx.globalAlpha = life;
+            ctx.fillStyle = p.color;
+            ctx.shadowColor = p.color;
+            ctx.shadowBlur = 10 * ratio;
+            ctx.beginPath();
+            ctx.arc(hx, hy, 1.7 * ratio, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.shadowBlur = 0;
+        }
+
+        function drawPing(ping) {
+            var t = ping.progress;
+            ctx.globalAlpha = (1 - t) * 0.55;
+            ctx.strokeStyle = ping.color;
+            ctx.lineWidth = 1 * ratio;
+            ctx.beginPath();
+            ctx.arc(ping.x, ping.y, (2 + t * 14) * ratio, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+
+        function frame(now) {
+            var dt = lastFrame ? Math.min(now - lastFrame, 64) : 16;
+            lastFrame = now;
+
+            sinceSpawn += dt;
+            if (sinceSpawn >= SPAWN_MS) {
+                sinceSpawn = 0;
+                spawn();
+            }
+
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+            for (var i = packets.length - 1; i >= 0; i--) {
+                var p = packets[i];
+                p.progress += dt / p.duration;
+                if (p.progress >= 1) {
+                    pings.push({
+                        x: p.to.x,
+                        y: p.to.y,
+                        progress: 0,
+                        duration: p.critical ? 1000 : 640,
+                        color: p.color
+                    });
+                    packets.splice(i, 1);
+                    continue;
+                }
+                drawPacket(p);
+            }
+
+            for (var j = pings.length - 1; j >= 0; j--) {
+                var ping = pings[j];
+                ping.progress += dt / ping.duration;
+                if (ping.progress >= 1) {
+                    pings.splice(j, 1);
+                    continue;
+                }
+                drawPing(ping);
+            }
+
+            ctx.globalAlpha = 1;
+            window.requestAnimationFrame(frame);
+        }
+
+        window.requestAnimationFrame(frame);
+    }
+
+    start(0);
+})();


### PR DESCRIPTION
Mockup of a new theme direction. Keeps the white-matter identity — node network, brain plate, connectivity — and pushes it toward the security-operations register the blog's subject matter already implies.

Nothing under `themes/PaperMod` is modified. This is four `assets/css/extended/*.css` files, two partial overrides, and one JS file. Delete those and the site is exactly as it was.

## What changed visually

**Palette.** Near-black base, one signal colour (cyan `#35e0d0`) doing all accent work. The existing logo blue `#67a2c9` is kept as secondary so the lineage is intact. Every accent derives from two variables at the top of `signal-01-vars.css` — retheming is a two-line change.

**Type.** System monospace for all metadata: nav, dates, tags, breadcrumbs, TOC, footer, page kickers. Body copy stays as-is. This is the single largest "this is a security blog" signal and it costs nothing. Deliberately no webfont — the onion mirror should not need a third-party font request to render.

**Backdrop.** Five fixed layers: brain plate (tinted into the signal colour and treated as texture rather than photograph), hairline survey grid, the particle network, a colour grade, and a slow scan sweep.

**Particles.** Kept, recoloured, and given something to do. Packets travel the links and ping the node they land on — occasionally in the alert colour. Reads as neurons or as traffic on a monitored network; it is meant to be both.

**Components.** Cards read as nodes: hairline border, corner ticks, an accent rail that lights on hover. Long-form posts get their own reading surface. Code blocks get terminal chrome with a `$` prompt. Tags are bracketed mono chips, with security tags in the alert colour. Markdown-style `##` / `###` gutter markers on wide viewports, echoing the `>#` logo. A telemetry rail under the header states how the site is actually served — every claim on it is true of the deployment.

## Bugs fixed along the way

- `particles.js` threw `Uncaught ReferenceError: Stats is not defined` on **every page load**. The stats.js FPS counter was copied verbatim from the source CodePen and stats.js was never loaded on this site.
- `#particles-js` was `position: absolute; height: 100%`, which resolves against the initial containing block — the neuron field only ever covered the first viewport and every page went flat below the fold. It is a real fixed backdrop now.
- `layouts/partials/particles.html` opened `<div class="site-wrapper">` and never closed it, leaving the browser to auto-repair the document.
- Embedded GitHub gists rendered as white slabs mid-post, which is glaring on a dark site and affects several of the homelab write-ups. The embed is same-document rather than an iframe, so it is simply restyled to match.
- `prefers-reduced-motion` is now honoured: static network, no packets, no sweep.

## Verified

Clean production build (363 pages, no errors). No console errors on load, normal or reduced-motion. Checked home, post, list, tags and a code-heavy post at 1440px, and the homepage at a true 390px via a fixed-width iframe.

## Not addressed here

- **Duplicate cover images.** Several posts set `cover.image` in front matter *and* re-embed the same image as the first line of the body, so it renders twice. That is a content issue from the WordPress migration, not a theme one — worth a separate sweep.
- `static/js/particles.js` is left in place so the two versions can be compared. Delete it if this direction is accepted.
- `static/js/index.js`, `jquery.js` and `jquery.fitvids.js` look like leftovers from the pre-Hugo Casper theme and appear unreferenced.
- Google Analytics is still on the deprecated UA property; Hugo warns on every build.