### PR TITLE
Portfolio section mockup — four domains, sourced from all 28 resumes

### DIFF
--- a/assets/css/extended/signal-01-vars.css
+++ b/assets/css/extended/signal-01-vars.css
@@ -48,6 +48,11 @@
     /* --- geometry ------------------------------------------------------- */
     --radius: 4px;
     --wm-tick: 7px;
+
+    /* Nine top-level nav items in a monospace face no longer fit beside the
+       logo at the theme's 1024px. Widening the bar keeps the type scale
+       instead of shrinking the labels to fit. */
+    --nav-width: 1100px;
 }
 
 /* PaperMod is hard-pinned to dark here (defaultTheme: dark + toggle disabled),

--- a/assets/css/extended/signal-02-shell.css
+++ b/assets/css/extended/signal-02-shell.css
@@ -171,7 +171,7 @@ body {
     font-size: 0.8rem;
     letter-spacing: 0.01em;
     color: var(--wm-dim);
-    padding: 5px 10px;
+    padding: 5px 8px;
     border-radius: 3px;
     border: 1px solid transparent;
     transition: color 0.16s ease, background 0.16s ease, border-color 0.16s ease;

--- a/assets/css/extended/signal-05-portfolio.css
+++ b/assets/css/extended/signal-05-portfolio.css
@@ -48,18 +48,6 @@
     margin: 0 0 18px;
 }
 
-/* clearance reads as a credential badge, not as body text */
-.portfolio-clearance {
-    display: inline-block;
-    margin-inline-start: 6px;
-    padding: 2px 8px;
-    border: 1px solid var(--wm-signal-dim);
-    border-radius: 3px;
-    background: var(--wm-signal-haze);
-    color: var(--wm-signal);
-    font-size: 0.72rem;
-}
-
 .portfolio-positioning {
     max-width: 74ch;
     margin: 0 0 22px;

--- a/assets/css/extended/signal-05-portfolio.css
+++ b/assets/css/extended/signal-05-portfolio.css
@@ -1,9 +1,9 @@
 /* ============================================================================
    SIGNAL — portfolio
    ----------------------------------------------------------------------------
-   Two lenses on the same person: what he runs, and what he builds. Roles are
-   drawn as nodes on a link line so the page uses the same graph vocabulary as
-   the backdrop rather than inventing a second one.
+   Four practice areas given equal weight, then experience, shipped work and
+   credentials. Roles are drawn as nodes on a link line so the page uses the
+   same graph vocabulary as the backdrop rather than inventing a second one.
    ========================================================================== */
 
 /* The portfolio needs more room than the reading measure. Scoped with :has()
@@ -46,6 +46,18 @@
     font-size: 0.78rem;
     color: var(--wm-dim);
     margin: 0 0 18px;
+}
+
+/* clearance reads as a credential badge, not as body text */
+.portfolio-clearance {
+    display: inline-block;
+    margin-inline-start: 6px;
+    padding: 2px 8px;
+    border: 1px solid var(--wm-signal-dim);
+    border-radius: 3px;
+    background: var(--wm-signal-haze);
+    color: var(--wm-signal);
+    font-size: 0.72rem;
 }
 
 .portfolio-positioning {
@@ -442,4 +454,79 @@
     font-size: 0.72rem;
     letter-spacing: 0.04em;
     color: var(--wm-faint);
+}
+
+/* --- domain cards -------------------------------------------------------------
+   The four practice areas. Given equal visual weight on purpose: the work spans
+   all of them and no single one is the frame around the others. */
+.domain-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 14px;
+}
+
+.domain-card {
+    position: relative;
+    padding: 22px 24px 20px;
+    background: color-mix(in srgb, var(--wm-panel) 88%, transparent);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    transition: border-color 0.2s ease;
+}
+
+.domain-card::before {
+    content: "";
+    position: absolute;
+    inset-block: -1px;
+    inset-inline-start: -1px;
+    width: 2px;
+    border-radius: var(--radius) 0 0 var(--radius);
+    background: var(--wm-signal-dim);
+}
+
+.domain-card:hover { border-color: var(--wm-signal-ghost); }
+
+.domain-card__title {
+    margin: 0 0 8px;
+    font-size: 1.14rem;
+    letter-spacing: -0.015em;
+    color: var(--wm-head);
+}
+
+.domain-card__blurb {
+    margin: 0 0 14px;
+    font-size: 0.92rem;
+    line-height: 1.6;
+    color: var(--wm-dim);
+}
+
+.domain-card__proof {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.domain-card__proof li {
+    position: relative;
+    padding-inline-start: 18px;
+    margin-bottom: 7px;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--wm-text);
+}
+
+/* a link stub rather than a bullet, matching the graph vocabulary */
+.domain-card__proof li::before {
+    content: "";
+    position: absolute;
+    inset-inline-start: 0;
+    top: 0.62em;
+    width: 9px;
+    height: 1px;
+    background: var(--wm-signal);
+    opacity: 0.55;
+}
+
+@media (max-width: 520px) {
+    .domain-grid { grid-template-columns: 1fr; }
 }

--- a/assets/css/extended/signal-05-portfolio.css
+++ b/assets/css/extended/signal-05-portfolio.css
@@ -1,0 +1,445 @@
+/* ============================================================================
+   SIGNAL — portfolio
+   ----------------------------------------------------------------------------
+   Two lenses on the same person: what he runs, and what he builds. Roles are
+   drawn as nodes on a link line so the page uses the same graph vocabulary as
+   the backdrop rather than inventing a second one.
+   ========================================================================== */
+
+/* The portfolio needs more room than the reading measure. Scoped with :has()
+   so no other page is affected; without :has() support it simply stays at the
+   default width and the grids collapse to one column. */
+.main:has(.portfolio) {
+    max-width: calc(1040px + var(--gap) * 2);
+}
+
+.portfolio {
+    padding: 10px 38px 40px;
+}
+
+@media (max-width: 700px) {
+    .portfolio { padding: 6px 18px 28px; }
+}
+
+/* --- head ------------------------------------------------------------------ */
+.portfolio-head {
+    padding: 18px 0 30px;
+    border-bottom: 1px solid var(--wm-line);
+}
+
+.portfolio-kicker {
+    font-family: var(--wm-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--wm-signal);
+    margin: 0 0 10px;
+}
+
+.portfolio .post-title {
+    margin: 0 0 8px;
+    font-size: 2.4rem;
+}
+
+.portfolio-role {
+    font-family: var(--wm-mono);
+    font-size: 0.78rem;
+    color: var(--wm-dim);
+    margin: 0 0 18px;
+}
+
+.portfolio-positioning {
+    max-width: 74ch;
+    margin: 0 0 22px;
+    padding-inline-start: 16px;
+    border-inline-start: 2px solid var(--wm-signal);
+    font-size: 1rem;
+    line-height: 1.68;
+    color: var(--wm-text);
+}
+
+.portfolio-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 0;
+}
+
+.portfolio-btn {
+    font-family: var(--wm-mono);
+    font-size: 0.76rem;
+    letter-spacing: 0.04em;
+    padding: 8px 16px;
+    border: 1px solid var(--wm-line-hi);
+    border-radius: var(--radius);
+    color: var(--wm-dim);
+    text-decoration: none;
+    transition: color 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+}
+
+.portfolio-btn:hover {
+    color: var(--wm-signal);
+    border-color: var(--wm-signal-dim);
+    background: var(--wm-signal-haze);
+}
+
+.portfolio-btn--primary {
+    color: var(--wm-void);
+    background: var(--wm-signal);
+    border-color: var(--wm-signal);
+    font-weight: 600;
+}
+
+.portfolio-btn--primary:hover {
+    color: var(--wm-void);
+    background: color-mix(in srgb, var(--wm-signal) 82%, #ffffff);
+    border-color: var(--wm-signal);
+}
+
+/* --- signal tiles ----------------------------------------------------------- */
+.signal-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin: 26px 0 8px;
+}
+
+.signal-tile {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 16px 16px 14px;
+    background: color-mix(in srgb, var(--wm-signal) 4%, transparent);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+}
+
+.signal-tile::after {
+    content: "";
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    width: var(--wm-tick);
+    height: var(--wm-tick);
+    border-top: 1px solid var(--wm-signal-ghost);
+    border-right: 1px solid var(--wm-signal-ghost);
+}
+
+.signal-tile__value {
+    font-family: var(--wm-mono);
+    font-size: 1.85rem;
+    line-height: 1.05;
+    color: var(--wm-signal);
+    letter-spacing: -0.02em;
+}
+
+.signal-tile__label {
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--wm-text);
+}
+
+.signal-tile__note {
+    font-size: 0.78rem;
+    line-height: 1.45;
+    color: var(--wm-faint);
+}
+
+/* --- lens sections ---------------------------------------------------------- */
+.lens {
+    margin-top: 46px;
+    scroll-margin-top: 90px;
+}
+
+.lens-head {
+    margin-bottom: 22px;
+}
+
+.lens-kicker {
+    display: block;
+    font-family: var(--wm-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--wm-faint);
+}
+
+.lens-title {
+    margin: 4px 0 8px;
+    font-size: 1.65rem;
+    letter-spacing: -0.02em;
+    color: var(--wm-head);
+}
+
+.lens-title::before {
+    content: "// ";
+    font-family: var(--wm-mono);
+    font-size: 0.72em;
+    color: var(--wm-signal);
+}
+
+.lens-blurb {
+    max-width: 70ch;
+    margin: 0;
+    color: var(--wm-dim);
+    line-height: 1.62;
+}
+
+.sub-head {
+    margin: 38px 0 16px;
+    font-family: var(--wm-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--wm-dim);
+}
+
+/* --- role track (nodes on a link line) --------------------------------------- */
+.track {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+}
+
+.track-node {
+    position: relative;
+    display: grid;
+    grid-template-columns: 118px 1fr;
+    gap: 30px;
+    padding: 0 0 30px 0;
+}
+
+/* the link line, drawn between node dots */
+.track-node::before {
+    content: "";
+    position: absolute;
+    left: 132px;
+    top: 14px;
+    bottom: -6px;
+    width: 1px;
+    background: linear-gradient(to bottom,
+        var(--wm-line-hi), color-mix(in srgb, var(--wm-line-hi) 20%, transparent));
+}
+
+.track-node:last-child::before { display: none; }
+
+/* the node itself */
+.track-node::after {
+    content: "";
+    position: absolute;
+    left: 129px;
+    top: 8px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--wm-panel);
+    border: 1px solid var(--wm-line-hi);
+}
+
+.track-node--live::after {
+    background: var(--wm-signal);
+    border-color: var(--wm-signal);
+    box-shadow: 0 0 12px var(--wm-signal);
+}
+
+.track-node__meta {
+    text-align: end;
+    padding-top: 2px;
+}
+
+.track-node__period {
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    color: var(--wm-faint);
+    white-space: nowrap;
+}
+
+
+.track-node__title {
+    margin: 0;
+    font-size: 1.12rem;
+    color: var(--wm-head);
+    letter-spacing: -0.01em;
+}
+
+.track-node__org {
+    margin: 3px 0 12px;
+    font-family: var(--wm-mono);
+    font-size: 0.76rem;
+    color: var(--wm-signal-2);
+}
+
+.track-node__org span { color: var(--wm-faint); }
+
+.track-node__points {
+    margin: 0;
+    padding-inline-start: 18px;
+    color: var(--wm-text);
+}
+
+.track-node__points li {
+    margin-bottom: 7px;
+    line-height: 1.6;
+    font-size: 0.94rem;
+}
+
+.track-node__points li::marker { color: var(--wm-signal-dim); }
+
+@media (max-width: 700px) {
+    .track-node { grid-template-columns: 1fr; gap: 6px; }
+    .track-node::before,
+    .track-node::after { display: none; }
+    .track-node__meta { text-align: start; }
+    .track-node__body { padding-inline-start: 0; }
+}
+
+/* --- chips ------------------------------------------------------------------- */
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+}
+
+.chip-row li {
+    font-family: var(--wm-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.02em;
+    color: var(--wm-dim);
+    background: color-mix(in srgb, var(--wm-panel-hi) 80%, transparent);
+    border: 1px solid var(--wm-line);
+    border-radius: 3px;
+    padding: 3px 8px;
+}
+
+.chip-row--sm li { font-size: 0.64rem; padding: 2px 7px; }
+
+.chip-row--wide { margin: 0 0 26px; gap: 8px; }
+.chip-row--wide li { padding: 5px 11px; font-size: 0.72rem; }
+
+.chip-row .chip--primary {
+    color: var(--wm-signal);
+    border-color: var(--wm-signal-dim);
+    background: var(--wm-signal-haze);
+    font-weight: 600;
+}
+
+/* --- card grids --------------------------------------------------------------- */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+    gap: 14px;
+}
+
+.card-grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin-top: 14px;
+}
+
+.repo-card {
+    position: relative;
+    display: block;
+    padding: 18px 18px 16px;
+    background: color-mix(in srgb, var(--wm-panel) 88%, transparent);
+    border: 1px solid var(--wm-line);
+    border-radius: var(--radius);
+    text-decoration: none;
+    transition: border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.repo-card:hover {
+    border-color: var(--wm-signal-ghost);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 26px -18px var(--wm-signal);
+}
+
+.repo-card__lang {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--wm-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--wm-faint);
+}
+
+.repo-card__lang::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--wm-faint);
+}
+
+.repo-card__lang[data-lang="Python"]::before     { background: #4b8bbe; }
+.repo-card__lang[data-lang="TypeScript"]::before { background: #3178c6; }
+.repo-card__lang[data-lang="Swift"]::before      { background: #f05138; }
+.repo-card__lang[data-lang="YAML"]::before       { background: #9ae08a; }
+
+.repo-card__name {
+    margin: 8px 0 6px;
+    font-family: var(--wm-mono);
+    font-size: 1rem;
+    color: var(--wm-head);
+    letter-spacing: -0.01em;
+}
+
+.repo-card:hover .repo-card__name { color: var(--wm-signal); }
+
+.repo-card__blurb {
+    margin: 0;
+    font-size: 0.88rem;
+    line-height: 1.55;
+    color: var(--wm-dim);
+}
+
+/* --- mini cards ---------------------------------------------------------------- */
+.mini-card {
+    padding: 16px 18px;
+    background: color-mix(in srgb, var(--wm-panel) 82%, transparent);
+    border: 1px solid var(--wm-line);
+    border-inline-start: 2px solid var(--wm-signal-dim);
+    border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.mini-card__period {
+    margin: 0 0 6px;
+    font-family: var(--wm-mono);
+    font-size: 0.68rem;
+    color: var(--wm-faint);
+}
+
+.mini-card__title {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--wm-head);
+}
+
+.mini-card__org {
+    margin: 3px 0 8px;
+    font-family: var(--wm-mono);
+    font-size: 0.74rem;
+    color: var(--wm-signal-2);
+}
+
+.mini-card__note {
+    margin: 0;
+    font-size: 0.88rem;
+    line-height: 1.55;
+    color: var(--wm-dim);
+}
+
+.affiliations {
+    margin: 22px 0 0;
+    font-family: var(--wm-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    color: var(--wm-faint);
+}

--- a/config.yml
+++ b/config.yml
@@ -29,9 +29,12 @@ languages:
                 - name: Posts
                   url: posts
                   weight: 5
+                - name: Portfolio
+                  url: portfolio/
+                  weight: 6
                 - name: Apps
                   url: apps/
-                  weight: 6
+                  weight: 7
                 - name: Gear & Tools
                   url: recommended-products/
                   weight: 7

--- a/content/portfolio.md
+++ b/content/portfolio.md
@@ -1,0 +1,13 @@
+---
+title: "Portfolio"
+layout: portfolio
+url: "/portfolio/"
+description: "Customer Success and Services leadership, and the software behind it — Robert D. White."
+summary: "Customer Success and Services leadership, and the software behind it."
+ShowToc: false
+ShowBreadCrumbs: false
+ShowReadingTime: false
+ShowPostNavLinks: false
+ShowShareButtons: false
+hideMeta: true
+---

--- a/data/portfolio.yml
+++ b/data/portfolio.yml
@@ -18,7 +18,6 @@ positioning: >
   setting strategy with a board and in a terminal at 1am.
 
 location: "Cincinnati, OH · Remote (US)"
-clearance: "Active U.S. DoD Secret Clearance"
 
 signals:
   - value: "1,000+"
@@ -57,7 +56,7 @@ domains:
       real — government, defense, healthcare and regulated SaaS — and translating
       technical risk into decisions a board can act on.
     proof:
-      - "CISSP; active U.S. DoD Secret clearance"
+      - "CISSP-certified; security programs built and matured end to end"
       - "Programs aligned to NIST 800-53, CSF, RMF, CMMC and zero-trust — the control families under CJIS, FedRAMP, SOC 2, ISO 27001 and HIPAA"
       - "Stood up penetration-testing, incident-response and GRC practices from scratch"
       - "Incident response for state critical infrastructure; government cloud (GCC-High)"
@@ -203,7 +202,6 @@ certifications:
   primary: "CISSP"
   items:
     - "CISSP"
-    - "Active U.S. DoD Secret Clearance"
     - "Certified AI Trust Practitioner"
     - "Certified DSPM Architect"
     - "Certified Security for AI Fundamentals"

--- a/data/portfolio.yml
+++ b/data/portfolio.yml
@@ -1,82 +1,141 @@
 # Portfolio content. Kept as data rather than markup so the page can be
-# reordered or re-skinned without touching layout, and so nothing here has to
-# be duplicated in HTML.
+# reordered or re-skinned without touching layout.
+#
+# Source: the 28 role-tailored resumes in ~/Documents/personas/Job Search,
+# not any single one of them. Those resumes target five distinct tracks — AI
+# enablement/transformation, security and CISO, CIO and IT leadership, customer
+# success and services, and TPM/Field CTO — so the page leads with domains
+# rather than with one function. Titles follow the resumes, which are
+# consistent across all 28.
 #
 # PUBLIC PAGE — deliberately excludes phone number and street-level location.
-# Titles mirror what is publicly verifiable on LinkedIn.
 
 positioning: >
-  Customer Success and Services leader who both builds and operates. I stand up
-  professional services and enablement functions from scratch, take over existing
-  CS and Support teams and drive measurable gains in retention and quality, and
-  own outcomes across the customer lifecycle. CISSP-level fluency in SOC 2,
-  ISO 27001, HIPAA and NIST — translated into customer-facing delivery rather
-  than left in a policy document.
+  Technology leader with 12+ years turning emerging technology — AI, security,
+  cloud — into governed, measurable outcomes in regulated, mission-critical
+  environments. I build functions from zero, enable the people who run them,
+  and ship the systems myself rather than only delegating. Equally at home
+  setting strategy with a board and in a terminal at 1am.
 
 location: "Cincinnati, OH · Remote (US)"
+clearance: "Active U.S. DoD Secret Clearance"
 
-# Quantified outcomes. Each is a personal or program result rather than an
-# internal company figure.
 signals:
+  - value: "1,000+"
+    label: "users, enterprise AI rollout"
+    note: "Claude / Cowork, led end to end"
+  - value: "20%"
+    label: "measured productivity gain"
+    note: "sustained after launch by a certification program"
   - value: "80%"
     label: "churn reduction"
     note: "strategic portfolio, Tanium"
-  - value: "+20%"
-    label: "accounts per engineer"
-    note: "within three months, via AI-enabled workflows"
-  - value: "1,000+"
-    label: "user genAI rollout"
-    note: "led end to end"
-  - value: "20"
-    label: "direct reports"
-    note: "plus 200+ supporting personnel"
+  - value: "12+"
+    label: "years"
+    note: "DoD, Fortune 20 and regulated enterprise"
 
-lenses:
-  - id: operate
-    kicker: "lens 01"
-    title: "Operate"
+# The four practice areas the resumes actually span. Customer Success is one of
+# them, not the frame around the others.
+domains:
+  - id: ai
+    title: "AI Enablement & Transformation"
     blurb: >
-      Building and running the customer-facing side of a security platform —
-      services, support, enablement, and the numbers they answer to.
-  - id: build
-    kicker: "lens 02"
-    title: "Build"
+      Taking AI from executive intent to governed production use — the use-case
+      roadmap, the integration layer, the guardrails, and the enablement that
+      makes adoption outlive the launch.
+    proof:
+      - "Company-wide generative-AI rollout to 1,000+ employees on Claude / Cowork"
+      - "Built the connector and MCP integration layer into core systems of record"
+      - "Agents and a reusable skill library, plus an academy and certification track"
+      - "Scoped-role and SSO governance; responsible-AI guardrails"
+    chips: ["applied AI", "agents & MCP", "governance", "change management", "FinOps"]
+
+  - id: security
+    title: "Security & Compliance"
     blurb: >
-      The same person, in a terminal. Everything below is running software, most
-      of it on a self-hosted Kubernetes cluster, all of it public source.
+      Building and maturing security programs in environments where the audit is
+      real — government, defense, healthcare and regulated SaaS — and translating
+      technical risk into decisions a board can act on.
+    proof:
+      - "CISSP; active U.S. DoD Secret clearance"
+      - "Programs aligned to NIST 800-53, CSF, RMF, CMMC and zero-trust — the control families under CJIS, FedRAMP, SOC 2, ISO 27001 and HIPAA"
+      - "Stood up penetration-testing, incident-response and GRC practices from scratch"
+      - "Incident response for state critical infrastructure; government cloud (GCC-High)"
+    chips: ["CISSP", "GRC", "zero-trust", "incident response", "DSPM"]
+
+  - id: platform
+    title: "Infrastructure & Platform"
+    blurb: >
+      Secure, automated infrastructure across multi-cloud and on-prem — set as
+      strategy, and still built with my own hands. The cluster running the
+      projects below is the working proof.
+    proof:
+      - "Multi-cloud across AWS, Azure and GCP; IAM and identity"
+      - "Terraform, CI/CD, containerisation and Kubernetes in production"
+      - "Secure DevOps, endpoint and DLP, developer self-service"
+      - "A self-hosted RKE2 cluster running every project in the next section"
+    chips: ["kubernetes", "terraform", "CI/CD", "multi-cloud", "GitOps"]
+
+  - id: cs
+    title: "Customer Success & Services"
+    blurb: >
+      Standing up professional services and enablement from nothing, taking over
+      existing CS and support teams, and owning the retention and quality numbers
+      they answer to.
+    proof:
+      - "Built a company's first onboarding, enablement, training and certification programs from the ground up"
+      - "Delivery methodology, service offerings and segmented packages reaching hundreds of companies and thousands of users"
+      - "Reduced churn 80% across a strategic portfolio by improving time-to-value and adoption"
+      - "Executive escalation point; advises C-suite and boards"
+    chips: ["NRR & expansion", "onboarding", "enablement", "services P&L", "CSAT & SLAs"]
+
+build_blurb: >
+  The claims above are not only on a resume. Everything here is running software,
+  most of it on the self-hosted Kubernetes cluster mentioned in Infrastructure,
+  all of it public source.
 
 roles:
   - org: "Cyera"
-    title: "Manager, Customer Success Engineering"
+    title: "Director, Customer Success"
     period: "2024 — present"
     context: "Data security posture management platform"
     current: true
     points:
-      - "Own the largest region and a portfolio spanning SMB through enterprise, accountable for net revenue retention, expansion, and customer outcomes."
-      - "Built the company's first onboarding, enablement, in-person training and Credly certification programs from the ground up — delivery methodology, service offerings, and repeatable segmented packages now reaching hundreds of companies and thousands of users."
-      - "Recruited and mentored the team that now runs those programs self-sufficiently."
-      - "Led a 1,000+ user generative-AI rollout and built AI-enabled workflows and reusable skills that raised accounts handled per engineer 20% in three months."
+      # The resumes say "~20% of total company ARR". Held back from the public
+      # page: it is a specific disclosure about a current employer's revenue
+      # distribution, and this page is indexed. Restore if you want it.
+      - "Own the largest region, accountable for net revenue retention, expansion and customer outcomes from SMB through enterprise."
+      - "Led a company-wide generative-AI rollout to 1,000+ employees — use-case strategy, the connector and MCP integration layer to core systems of record, scoped-role and SSO governance — delivering a measured 20% productivity gain."
+      - "Built the company's first onboarding, enablement, in-person training and certification programs from the ground up, now reaching hundreds of companies and thousands of users through a team I recruited and mentored."
       - "Lead customer-facing security reviews; translate SOC 2, ISO 27001 and NIST into delivery strategy. Executive escalation point, advising C-suite and boards."
-    tags: ["DSPM", "AI security", "NRR", "enablement"]
+    tags: ["applied AI", "DSPM", "NRR", "enablement"]
 
   - org: "Tanium"
-    title: "Enterprise Services Engineer"
+    title: "Cybersecurity Domain Architect / Enterprise Services Engineer"
     period: "2022 — 2024"
     context: "Fortune 20, hospital and government customers"
     points:
-      - "Led enterprise implementations, onboarding and support escalations; reduced churn 80% across a strategic portfolio by improving time-to-value, quality and adoption."
+      - "Led enterprise implementations, onboarding and escalations; reduced churn 80% across a strategic portfolio by improving time-to-value, quality and adoption."
       - "Codified repeatable delivery practice and enabled technical and non-technical teams as a Certified Instructor."
       - "Trusted advisor to CISOs and boards on security and compliance outcomes."
-    tags: ["implementation", "escalations", "instruction"]
+    tags: ["endpoint security", "implementation", "instruction"]
 
   - org: "Matrix Research"
-    title: "Systems Engineer"
+    title: "Lead Security & Systems Engineer"
     period: "2020 — 2022"
-    context: "Defense research"
+    context: "Defense research · DoD"
     points:
       - "Owned compliance and security programs aligned to NIST 800-series, CMMC and RMF — the control foundations underlying SOC 2, ISO 27001 and HIPAA."
-      - "Secured cloud and CI/CD environments across AWS and Azure, including IAM."
-    tags: ["NIST 800", "CMMC", "RMF"]
+      - "Secured cloud and CI/CD environments across AWS and Azure, including IAM and government cloud."
+    tags: ["NIST 800", "CMMC", "RMF", "GCC-High"]
+
+  - org: "computerDNA"
+    title: "Operational Systems Lead"
+    period: "2019 — 2020"
+    context: "Managed services"
+    points:
+      - "Ran systems and endpoint operations across a multi-client managed-services book, standardising delivery and tooling."
+    tags: ["systems", "endpoint", "MSP"]
 
   - org: "Towne Church"
     title: "Director of Technology"
@@ -95,7 +154,7 @@ service:
   - org: "Ohio Cyber Reserve"
     title: "Deputy Group Lead, Cincinnati Region"
     period: "2023 — 2025"
-    note: "Volunteer reservist. Team captain at the National Cyber Exercise and Competition — 1st in Ohio, 8th nationally."
+    note: "Volunteer reservist supporting incident response for state critical infrastructure. Team captain at the National Cyber Exercise and Competition — 1st in Ohio, 8th nationally."
 
 # Public repositories only. Private work is described but never linked.
 projects:
@@ -104,6 +163,11 @@ projects:
     blurb: "GitOps monorepo for a self-hosted RKE2 Kubernetes cluster — the platform every project below actually runs on."
     url: "https://github.com/RobertDWhite/whitehouse-rke2"
     tags: ["kubernetes", "gitops", "homelab"]
+  - name: "MCP server suite"
+    lang: "Python"
+    blurb: "Model Context Protocol servers exposing self-hosted services to AI agents — Search Console, Google News, FreshRSS, Monica, Jetlog and Congress data. The same integration pattern used at enterprise scale."
+    url: "https://github.com/RobertDWhite?tab=repositories&q=mcp"
+    tags: ["MCP", "agents", "ghcr"]
   - name: "weather-dashboard"
     lang: "TypeScript"
     blurb: "Self-hosted, NWS-grade weather operations console. VTEC alert parsing, NEXRAD and MRMS radar with playback, SPC severe products, aviation and marine feeds. Speaks CAP 1.2."
@@ -111,9 +175,14 @@ projects:
     tags: ["fastapi", "react", "CAP 1.2"]
   - name: "GrafLens"
     lang: "Swift"
-    blurb: "Native iOS viewer for Grafana. Dashboards, alerts, annotations, snapshots, and home-screen widgets for any panel. No ads, no tracking."
+    blurb: "Native iOS viewer for Grafana. Dashboards, alerts, annotations, snapshots and home-screen widgets for any panel. No ads, no tracking."
     url: "https://github.com/whitematter-tech/graflens"
     tags: ["iOS", "widgets", "open source"]
+  - name: "pages-mcp"
+    lang: "Python"
+    blurb: "Static-site host with an MCP upload tool, so an agent can publish an artifact and get back a URL."
+    url: "https://github.com/RobertDWhite/pages-mcp"
+    tags: ["MCP", "hosting"]
   - name: "congress-trades"
     lang: "Python"
     blurb: "Congressional trade tracker — disclosure ingestion, normalisation and a React front end."
@@ -124,16 +193,6 @@ projects:
     blurb: "Astronomy and space-weather dashboard: real-time solar imagery, geomagnetic conditions and sky data."
     url: "https://github.com/RobertDWhite/astronomy"
     tags: ["fastapi", "react"]
-  - name: "MCP server suite"
-    lang: "Python"
-    blurb: "Model Context Protocol servers exposing self-hosted services to AI agents — Search Console, Google News, FreshRSS, Monica, Jetlog and Congress data."
-    url: "https://github.com/RobertDWhite?tab=repositories&q=mcp"
-    tags: ["MCP", "agents", "ghcr"]
-  - name: "pages-mcp"
-    lang: "Python"
-    blurb: "Static-site host with an MCP upload tool, so an agent can publish an artifact and get back a URL."
-    url: "https://github.com/RobertDWhite/pages-mcp"
-    tags: ["MCP", "hosting"]
   - name: "home-assistant"
     lang: "YAML"
     blurb: "Home automation config covering circadian lighting, VLAN-segmented IoT and presence."
@@ -144,6 +203,7 @@ certifications:
   primary: "CISSP"
   items:
     - "CISSP"
+    - "Active U.S. DoD Secret Clearance"
     - "Certified AI Trust Practitioner"
     - "Certified DSPM Architect"
     - "Certified Security for AI Fundamentals"

--- a/data/portfolio.yml
+++ b/data/portfolio.yml
@@ -1,0 +1,169 @@
+# Portfolio content. Kept as data rather than markup so the page can be
+# reordered or re-skinned without touching layout, and so nothing here has to
+# be duplicated in HTML.
+#
+# PUBLIC PAGE — deliberately excludes phone number and street-level location.
+# Titles mirror what is publicly verifiable on LinkedIn.
+
+positioning: >
+  Customer Success and Services leader who both builds and operates. I stand up
+  professional services and enablement functions from scratch, take over existing
+  CS and Support teams and drive measurable gains in retention and quality, and
+  own outcomes across the customer lifecycle. CISSP-level fluency in SOC 2,
+  ISO 27001, HIPAA and NIST — translated into customer-facing delivery rather
+  than left in a policy document.
+
+location: "Cincinnati, OH · Remote (US)"
+
+# Quantified outcomes. Each is a personal or program result rather than an
+# internal company figure.
+signals:
+  - value: "80%"
+    label: "churn reduction"
+    note: "strategic portfolio, Tanium"
+  - value: "+20%"
+    label: "accounts per engineer"
+    note: "within three months, via AI-enabled workflows"
+  - value: "1,000+"
+    label: "user genAI rollout"
+    note: "led end to end"
+  - value: "20"
+    label: "direct reports"
+    note: "plus 200+ supporting personnel"
+
+lenses:
+  - id: operate
+    kicker: "lens 01"
+    title: "Operate"
+    blurb: >
+      Building and running the customer-facing side of a security platform —
+      services, support, enablement, and the numbers they answer to.
+  - id: build
+    kicker: "lens 02"
+    title: "Build"
+    blurb: >
+      The same person, in a terminal. Everything below is running software, most
+      of it on a self-hosted Kubernetes cluster, all of it public source.
+
+roles:
+  - org: "Cyera"
+    title: "Manager, Customer Success Engineering"
+    period: "2024 — present"
+    context: "Data security posture management platform"
+    current: true
+    points:
+      - "Own the largest region and a portfolio spanning SMB through enterprise, accountable for net revenue retention, expansion, and customer outcomes."
+      - "Built the company's first onboarding, enablement, in-person training and Credly certification programs from the ground up — delivery methodology, service offerings, and repeatable segmented packages now reaching hundreds of companies and thousands of users."
+      - "Recruited and mentored the team that now runs those programs self-sufficiently."
+      - "Led a 1,000+ user generative-AI rollout and built AI-enabled workflows and reusable skills that raised accounts handled per engineer 20% in three months."
+      - "Lead customer-facing security reviews; translate SOC 2, ISO 27001 and NIST into delivery strategy. Executive escalation point, advising C-suite and boards."
+    tags: ["DSPM", "AI security", "NRR", "enablement"]
+
+  - org: "Tanium"
+    title: "Enterprise Services Engineer"
+    period: "2022 — 2024"
+    context: "Fortune 20, hospital and government customers"
+    points:
+      - "Led enterprise implementations, onboarding and support escalations; reduced churn 80% across a strategic portfolio by improving time-to-value, quality and adoption."
+      - "Codified repeatable delivery practice and enabled technical and non-technical teams as a Certified Instructor."
+      - "Trusted advisor to CISOs and boards on security and compliance outcomes."
+    tags: ["implementation", "escalations", "instruction"]
+
+  - org: "Matrix Research"
+    title: "Systems Engineer"
+    period: "2020 — 2022"
+    context: "Defense research"
+    points:
+      - "Owned compliance and security programs aligned to NIST 800-series, CMMC and RMF — the control foundations underlying SOC 2, ISO 27001 and HIPAA."
+      - "Secured cloud and CI/CD environments across AWS and Azure, including IAM."
+    tags: ["NIST 800", "CMMC", "RMF"]
+
+  - org: "Towne Church"
+    title: "Director of Technology"
+    period: "2013 — 2019"
+    context: "Non-profit"
+    points:
+      - "Built and led cross-functional teams of up to 20 direct reports and 200+ supporting personnel."
+      - "Owned budgets, vendor relationships and service delivery standards."
+    tags: ["team building", "budget", "vendor"]
+
+service:
+  - org: "Point University · Defiance College"
+    title: "Adjunct Professor — IT, AI & Cybersecurity"
+    period: "2024 — present"
+    note: "Curriculum in AI-enabled operations, cloud and security. Courses taught include Operating System Security and Ethical Hacking."
+  - org: "Ohio Cyber Reserve"
+    title: "Deputy Group Lead, Cincinnati Region"
+    period: "2023 — 2025"
+    note: "Volunteer reservist. Team captain at the National Cyber Exercise and Competition — 1st in Ohio, 8th nationally."
+
+# Public repositories only. Private work is described but never linked.
+projects:
+  - name: "whitehouse-rke2"
+    lang: "Python"
+    blurb: "GitOps monorepo for a self-hosted RKE2 Kubernetes cluster — the platform every project below actually runs on."
+    url: "https://github.com/RobertDWhite/whitehouse-rke2"
+    tags: ["kubernetes", "gitops", "homelab"]
+  - name: "weather-dashboard"
+    lang: "TypeScript"
+    blurb: "Self-hosted, NWS-grade weather operations console. VTEC alert parsing, NEXRAD and MRMS radar with playback, SPC severe products, aviation and marine feeds. Speaks CAP 1.2."
+    url: "https://github.com/RobertDWhite/weather-dashboard"
+    tags: ["fastapi", "react", "CAP 1.2"]
+  - name: "GrafLens"
+    lang: "Swift"
+    blurb: "Native iOS viewer for Grafana. Dashboards, alerts, annotations, snapshots, and home-screen widgets for any panel. No ads, no tracking."
+    url: "https://github.com/whitematter-tech/graflens"
+    tags: ["iOS", "widgets", "open source"]
+  - name: "congress-trades"
+    lang: "Python"
+    blurb: "Congressional trade tracker — disclosure ingestion, normalisation and a React front end."
+    url: "https://github.com/RobertDWhite/congress-trades"
+    tags: ["fastapi", "react", "data"]
+  - name: "astronomy"
+    lang: "TypeScript"
+    blurb: "Astronomy and space-weather dashboard: real-time solar imagery, geomagnetic conditions and sky data."
+    url: "https://github.com/RobertDWhite/astronomy"
+    tags: ["fastapi", "react"]
+  - name: "MCP server suite"
+    lang: "Python"
+    blurb: "Model Context Protocol servers exposing self-hosted services to AI agents — Search Console, Google News, FreshRSS, Monica, Jetlog and Congress data."
+    url: "https://github.com/RobertDWhite?tab=repositories&q=mcp"
+    tags: ["MCP", "agents", "ghcr"]
+  - name: "pages-mcp"
+    lang: "Python"
+    blurb: "Static-site host with an MCP upload tool, so an agent can publish an artifact and get back a URL."
+    url: "https://github.com/RobertDWhite/pages-mcp"
+    tags: ["MCP", "hosting"]
+  - name: "home-assistant"
+    lang: "YAML"
+    blurb: "Home automation config covering circadian lighting, VLAN-segmented IoT and presence."
+    url: "https://github.com/RobertDWhite/home-assistant"
+    tags: ["automation", "iot"]
+
+certifications:
+  primary: "CISSP"
+  items:
+    - "CISSP"
+    - "Certified AI Trust Practitioner"
+    - "Certified DSPM Architect"
+    - "Certified Security for AI Fundamentals"
+    - "Microsoft AZ-900"
+    - "Microsoft SC-900"
+    - "Tanium Certified Instructor (TCO, TCA, TCSCD, TCP)"
+    - "Apple Certified Support Professional"
+    - "Deep Instinct Certified Engineer"
+    - "MDM Certified (Jamf, Mosyle)"
+    - "FCC Amateur Radio — W3RDW"
+
+education:
+  - degree: "M.S. Information Technology"
+    school: "University of the Cumberlands"
+    year: "2022"
+  - degree: "B.A. Psychology"
+    school: "Miami University"
+    year: "2015"
+
+affiliations:
+  - "Center for Internet Security (CIS)"
+  - "InfraGard"
+  - "Microsoft Partner Network"

--- a/layouts/_default/portfolio.html
+++ b/layouts/_default/portfolio.html
@@ -10,7 +10,10 @@
     <p class="portfolio-positioning">{{ $p.positioning }}</p>
     <p class="portfolio-actions">
       <a class="portfolio-btn portfolio-btn--primary" href="mailto:robert@whitematter.tech">Get in touch</a>
-      <a class="portfolio-btn" href="https://linkedin.white.fm" rel="noopener noreferrer">LinkedIn</a>
+      {{- /* Canonical URL rather than the linkedin.white.fm vanity redirect, which
+             currently 404s. A dead LinkedIn link on a job-search page is the one
+             broken link that cannot be tolerated. */}}
+      <a class="portfolio-btn" href="https://www.linkedin.com/in/robertdylanwhite/" rel="noopener noreferrer">LinkedIn</a>
       <a class="portfolio-btn" href="https://github.white.fm" rel="noopener noreferrer">GitHub</a>
     </p>
   </header>

--- a/layouts/_default/portfolio.html
+++ b/layouts/_default/portfolio.html
@@ -6,10 +6,7 @@
   <header class="portfolio-head">
     <p class="portfolio-kicker">// portfolio</p>
     <h1 class="post-title">{{ site.Params.homeInfoParams.Title }}</h1>
-    <p class="portfolio-role">
-      {{ $p.location }}
-      {{- with $p.clearance }} <span class="portfolio-clearance">{{ . }}</span>{{ end }}
-    </p>
+    <p class="portfolio-role">{{ $p.location }}</p>
     <p class="portfolio-positioning">{{ $p.positioning }}</p>
     <p class="portfolio-actions">
       <a class="portfolio-btn portfolio-btn--primary" href="mailto:robert@whitematter.tech">Get in touch</a>

--- a/layouts/_default/portfolio.html
+++ b/layouts/_default/portfolio.html
@@ -1,0 +1,130 @@
+{{- define "main" }}
+{{- $p := site.Data.portfolio }}
+
+<article class="post-single portfolio">
+
+  <header class="portfolio-head">
+    <p class="portfolio-kicker">// portfolio</p>
+    <h1 class="post-title">{{ site.Params.homeInfoParams.Title }}</h1>
+    <p class="portfolio-role">{{ $p.location }}</p>
+    <p class="portfolio-positioning">{{ $p.positioning }}</p>
+    <p class="portfolio-actions">
+      <a class="portfolio-btn portfolio-btn--primary" href="mailto:robert@whitematter.tech">Get in touch</a>
+      <a class="portfolio-btn" href="https://linkedin.white.fm" rel="noopener noreferrer">LinkedIn</a>
+      <a class="portfolio-btn" href="https://github.white.fm" rel="noopener noreferrer">GitHub</a>
+    </p>
+  </header>
+
+  {{- /* Quantified outcomes, read as instrument tiles rather than prose. */}}
+  <section class="signal-tiles" aria-label="Selected outcomes">
+    {{- range $p.signals }}
+    <div class="signal-tile">
+      <span class="signal-tile__value">{{ .value }}</span>
+      <span class="signal-tile__label">{{ .label }}</span>
+      <span class="signal-tile__note">{{ .note }}</span>
+    </div>
+    {{- end }}
+  </section>
+
+  {{- /* ---- lens 01: operate ------------------------------------------- */}}
+  {{- $operate := index (where $p.lenses "id" "operate") 0 }}
+  <section class="lens" id="operate">
+    <div class="lens-head">
+      <span class="lens-kicker">{{ $operate.kicker }}</span>
+      <h2 class="lens-title">{{ $operate.title }}</h2>
+      <p class="lens-blurb">{{ $operate.blurb }}</p>
+    </div>
+
+    {{- /* Roles as nodes on a link line — the same graph idea as the backdrop. */}}
+    <ol class="track">
+      {{- range $p.roles }}
+      <li class="track-node{{ if .current }} track-node--live{{ end }}">
+        <div class="track-node__meta">
+          <span class="track-node__period">{{ .period }}</span>
+        </div>
+        <div class="track-node__body">
+          <h3 class="track-node__title">{{ .title }}</h3>
+          <p class="track-node__org">{{ .org }}{{ with .context }} <span>· {{ . }}</span>{{ end }}</p>
+          <ul class="track-node__points">
+            {{- range .points }}<li>{{ . }}</li>{{ end }}
+          </ul>
+          {{- with .tags }}
+          <ul class="chip-row">
+            {{- range . }}<li>{{ . }}</li>{{ end }}
+          </ul>
+          {{- end }}
+        </div>
+      </li>
+      {{- end }}
+    </ol>
+
+    <h3 class="sub-head">Teaching &amp; service</h3>
+    <div class="card-grid card-grid--two">
+      {{- range $p.service }}
+      <div class="mini-card">
+        <p class="mini-card__period">{{ .period }}</p>
+        <h4 class="mini-card__title">{{ .title }}</h4>
+        <p class="mini-card__org">{{ .org }}</p>
+        <p class="mini-card__note">{{ .note }}</p>
+      </div>
+      {{- end }}
+    </div>
+  </section>
+
+  {{- /* ---- lens 02: build ---------------------------------------------- */}}
+  {{- $build := index (where $p.lenses "id" "build") 0 }}
+  <section class="lens" id="build">
+    <div class="lens-head">
+      <span class="lens-kicker">{{ $build.kicker }}</span>
+      <h2 class="lens-title">{{ $build.title }}</h2>
+      <p class="lens-blurb">{{ $build.blurb }}</p>
+    </div>
+
+    <div class="card-grid">
+      {{- range $p.projects }}
+      <a class="repo-card" href="{{ .url }}" rel="noopener noreferrer">
+        <span class="repo-card__lang" data-lang="{{ .lang }}">{{ .lang }}</span>
+        <h3 class="repo-card__name">{{ .name }}</h3>
+        <p class="repo-card__blurb">{{ .blurb }}</p>
+        {{- with .tags }}
+        <ul class="chip-row chip-row--sm">
+          {{- range . }}<li>{{ . }}</li>{{ end }}
+        </ul>
+        {{- end }}
+      </a>
+      {{- end }}
+    </div>
+  </section>
+
+  {{- /* ---- credentials -------------------------------------------------- */}}
+  <section class="lens" id="credentials">
+    <div class="lens-head">
+      <span class="lens-kicker">lens 03</span>
+      <h2 class="lens-title">Credentials</h2>
+    </div>
+
+    <ul class="chip-row chip-row--wide">
+      {{- range $p.certifications.items }}
+      <li{{ if eq . $p.certifications.primary }} class="chip--primary"{{ end }}>{{ . }}</li>
+      {{- end }}
+    </ul>
+
+    <div class="card-grid card-grid--two">
+      {{- range $p.education }}
+      <div class="mini-card">
+        <p class="mini-card__period">{{ .year }}</p>
+        <h4 class="mini-card__title">{{ .degree }}</h4>
+        <p class="mini-card__org">{{ .school }}</p>
+      </div>
+      {{- end }}
+    </div>
+
+    <p class="affiliations">
+      {{- range $i, $a := $p.affiliations }}{{ if $i }} · {{ end }}{{ $a }}{{ end -}}
+    </p>
+  </section>
+
+  {{- with .Content }}<div class="post-content">{{ . }}</div>{{ end }}
+
+</article>
+{{- end }}

--- a/layouts/_default/portfolio.html
+++ b/layouts/_default/portfolio.html
@@ -6,7 +6,10 @@
   <header class="portfolio-head">
     <p class="portfolio-kicker">// portfolio</p>
     <h1 class="post-title">{{ site.Params.homeInfoParams.Title }}</h1>
-    <p class="portfolio-role">{{ $p.location }}</p>
+    <p class="portfolio-role">
+      {{ $p.location }}
+      {{- with $p.clearance }} <span class="portfolio-clearance">{{ . }}</span>{{ end }}
+    </p>
     <p class="portfolio-positioning">{{ $p.positioning }}</p>
     <p class="portfolio-actions">
       <a class="portfolio-btn portfolio-btn--primary" href="mailto:robert@whitematter.tech">Get in touch</a>
@@ -15,7 +18,8 @@
     </p>
   </header>
 
-  {{- /* Quantified outcomes, read as instrument tiles rather than prose. */}}
+  {{- /* Quantified outcomes, read as instruments rather than prose. Chosen to
+         span domains rather than to sit inside any one of them. */}}
   <section class="signal-tiles" aria-label="Selected outcomes">
     {{- range $p.signals }}
     <div class="signal-tile">
@@ -26,16 +30,42 @@
     {{- end }}
   </section>
 
-  {{- /* ---- lens 01: operate ------------------------------------------- */}}
-  {{- $operate := index (where $p.lenses "id" "operate") 0 }}
-  <section class="lens" id="operate">
+  {{- /* ---- 01 domains --------------------------------------------------
+         The page leads with practice areas because the work spans several and
+         no single one of them is the whole picture. */}}
+  <section class="lens" id="domains">
     <div class="lens-head">
-      <span class="lens-kicker">{{ $operate.kicker }}</span>
-      <h2 class="lens-title">{{ $operate.title }}</h2>
-      <p class="lens-blurb">{{ $operate.blurb }}</p>
+      <span class="lens-kicker">01</span>
+      <h2 class="lens-title">Domains</h2>
+      <p class="lens-blurb">Four practice areas, one through-line: take something complex or new and make it operational, governed, and owned by the people who have to live with it.</p>
     </div>
 
-    {{- /* Roles as nodes on a link line — the same graph idea as the backdrop. */}}
+    <div class="domain-grid">
+      {{- range $p.domains }}
+      <section class="domain-card" id="{{ .id }}">
+        <h3 class="domain-card__title">{{ .title }}</h3>
+        <p class="domain-card__blurb">{{ .blurb }}</p>
+        <ul class="domain-card__proof">
+          {{- range .proof }}<li>{{ . }}</li>{{ end }}
+        </ul>
+        {{- with .chips }}
+        <ul class="chip-row chip-row--sm">
+          {{- range . }}<li>{{ . }}</li>{{ end }}
+        </ul>
+        {{- end }}
+      </section>
+      {{- end }}
+    </div>
+  </section>
+
+  {{- /* ---- 02 experience -------------------------------------------------
+         Roles as nodes on a link line — the same graph idea as the backdrop. */}}
+  <section class="lens" id="experience">
+    <div class="lens-head">
+      <span class="lens-kicker">02</span>
+      <h2 class="lens-title">Experience</h2>
+    </div>
+
     <ol class="track">
       {{- range $p.roles }}
       <li class="track-node{{ if .current }} track-node--live{{ end }}">
@@ -71,13 +101,12 @@
     </div>
   </section>
 
-  {{- /* ---- lens 02: build ---------------------------------------------- */}}
-  {{- $build := index (where $p.lenses "id" "build") 0 }}
+  {{- /* ---- 03 build ------------------------------------------------------ */}}
   <section class="lens" id="build">
     <div class="lens-head">
-      <span class="lens-kicker">{{ $build.kicker }}</span>
-      <h2 class="lens-title">{{ $build.title }}</h2>
-      <p class="lens-blurb">{{ $build.blurb }}</p>
+      <span class="lens-kicker">03</span>
+      <h2 class="lens-title">Build</h2>
+      <p class="lens-blurb">{{ $p.build_blurb }}</p>
     </div>
 
     <div class="card-grid">
@@ -96,10 +125,10 @@
     </div>
   </section>
 
-  {{- /* ---- credentials -------------------------------------------------- */}}
+  {{- /* ---- 04 credentials ------------------------------------------------ */}}
   <section class="lens" id="credentials">
     <div class="lens-head">
-      <span class="lens-kicker">lens 03</span>
+      <span class="lens-kicker">04</span>
       <h2 class="lens-title">Credentials</h2>
     </div>
 


### PR DESCRIPTION
A `/portfolio/` page in the Signal vocabulary, built from the **full set of 28 role-tailored resumes** in `~/Documents/personas/Job Search`, not any single one.

## Why it's shaped this way

The resumes target five distinct tracks, and the distribution matters:

| Track | Roles targeted |
|---|---|
| **AI enablement / transformation** | 12 — BeOne, ReWork, Vulcury, WM Synergy, GE Aerospace ×2, NICE, Asurint, DuPont, Foundever, Intradiem, McKesson |
| **Security / CISO** | 5 — Mi-Case, Sardine, Interdependence, ARIVE, Zippy |
| **CIO / IT leadership** | 3 — CIO Financial Services, UoPeople, Lightspeed |
| **Customer success / services** | 4 — Vanta, Hippocratic, Babylist, NxtPlay |
| **TPM / Field CTO** | 2 — Netflix, GitLab |

AI is the largest cluster; CS is roughly a seventh of the set. So the page leads with **four practice areas of equal weight** — AI Enablement & Transformation, Security & Compliance, Infrastructure & Platform, Customer Success & Services — under one through-line: *take something complex or new and make it operational, governed, and owned by the people who have to live with it.* CS is one of the four, not the frame around the others.

Roles render as **nodes on a link line**, reusing the backdrop's graph vocabulary.

## Recovered from the wider set (absent from the single Vanta resume)

- **The genAI rollout in actual detail**: Claude / Cowork to 1,000+ users, the connector and **MCP integration layer** to core systems of record, agents and a **reusable skill library**, an academy and certification track, scoped-role and SSO governance. v1 said only "1,000+ user genAI rollout."
- NIST 800-53 / CSF / RMF / CMMC, zero-trust, CJIS, FedRAMP, GCC-High
- Stood up **penetration-testing, incident-response and GRC practices from scratch**
- **Incident response for state critical infrastructure** (Ohio Cyber Reserve)
- Multi-cloud, **Terraform**, CI/CD and containerisation as first-class skills rather than homelab hobby
- **computerDNA** (2019–2020), present in 15 resumes but cut from the Vanta one

## Titles — resolved, with one thing left for the author

The 28 resumes **agree with each other**, so this is a consistent claim rather than a one-off:

- Cyera — **Director, Customer Success** (22 of 22)
- Tanium — **Cybersecurity Domain Architect / Enterprise Services Engineer** (15)
- Matrix Research — **Lead Security & Systems Engineer** (23)
- computerDNA — **Operational Systems Lead** (15)

The page uses these. **LinkedIn still shows more junior titles.** Since the page is public and indexed, a recruiter will cross-check; it needs to be one story.

## Deliberately kept off a public, indexed page

- **Clearance status.** Added in an earlier commit on this branch and since removed — publishing an active clearance on a personal site advertises to anyone scraping it that the holder is worth targeting, permanently and outside any hiring context where the disclosure is warranted. Employment context ("Defense research · DoD") stays; that is ordinary public employment history.
- **"~20% of total company ARR"** — a specific disclosure about a current employer's revenue distribution.
- Phone number; Middletown as a location (uses Cincinnati, already public on LinkedIn).
- Private repositories — only the 8 public ones are linked or named.

## Verified

Clean build (364 pages) on Hugo 0.160.1 and 0.140.2 (the version that actually deploys). No console errors. Checked at 1440px and a true 390px. Output audited: zero matches for the phone number, Middletown, the ARR figure, "clearance"/"Secret", and private-repo strings; 4 domains and 5 roles render.

## Also in this branch

Nav widened to 1100px — nine monospace items no longer fit beside the logo at the theme's 1024px, so adding "Portfolio" wrapped the header to two lines on **every** page.

## Note for later

`public/` is committed *and* gitignored, so the ignore rule does nothing and any `hugo server` run without `--renderToMemory` dirties ~229 tracked files. Worth a `git rm -r --cached public/` separately.