### PR TITLE
Make the particle network actually visible

### DIFF
--- a/assets/css/extended/signal-02-shell.css
+++ b/assets/css/extended/signal-02-shell.css
@@ -58,7 +58,7 @@ body {
    tinted into the signal colour so it reads as neural structure, not stock. */
 .wm-plate {
     background: url("/brain-dark.png") no-repeat 50% 42% / cover;
-    opacity: 0.8;
+    opacity: 0.68;
     filter: grayscale(1) brightness(1.25) contrast(1.15)
             sepia(1) hue-rotate(140deg) saturate(2);
 }

--- a/layouts/partials/particles.html
+++ b/layouts/partials/particles.html
@@ -7,12 +7,18 @@
             the first viewport. It is fixed now (see signal-02-shell.css).
 
        Order matters — these are all z-index:0 and stack by document order:
-       plate (texture) → grid (structure) → particles (the network) →
-       veil (grade) → scan (sweep). */ -}}
+       plate (texture) → grid (structure) → veil (grade) → particles (the
+       network) → scan (sweep).
+
+       The veil sits UNDER the particles deliberately. It exists to knock the
+       brain plate back so body copy wins; when it was layered over the network
+       as well it washed the nodes out to almost nothing, worst at the edges
+       where its vignette is strongest. Grading the plate and grading the
+       network are two different jobs. */ -}}
 <div class="wm-plate" aria-hidden="true"></div>
 <div class="wm-grid" aria-hidden="true"></div>
-<div id="particles-js"></div>
 <div class="wm-veil" aria-hidden="true"></div>
+<div id="particles-js"></div>
 <div class="wm-scan" aria-hidden="true"></div>
 
 {{- /* Telemetry rail: how this page is actually served. Every claim is true of

--- a/static/js/particles-signal.js
+++ b/static/js/particles-signal.js
@@ -23,7 +23,7 @@
 
     particlesJS("particles-js", {
         particles: {
-            number: { value: 38, density: { enable: true, value_area: 900 } },
+            number: { value: 46, density: { enable: true, value_area: 900 } },
             color: { value: [SIGNAL, SIGNAL_2, "#ffffff"] },
             shape: {
                 type: "circle",
@@ -31,17 +31,17 @@
                 polygon: { nb_sides: 5 }
             },
             opacity: {
-                value: 0.55,
+                value: 0.8,
                 random: true,
                 anim: {
                     enable: !reduceMotion,
                     speed: 0.5,
-                    opacity_min: 0.08,
+                    opacity_min: 0.3,
                     sync: false
                 }
             },
             size: {
-                value: 2.4,
+                value: 2.6,
                 random: true,
                 anim: {
                     enable: !reduceMotion,
@@ -54,8 +54,8 @@
                 enable: true,
                 distance: 155,
                 color: SIGNAL,
-                opacity: 0.24,
-                width: 1
+                opacity: 0.4,
+                width: 1.2
             },
             move: {
                 enable: !reduceMotion,


### PR DESCRIPTION
The network had faded to nearly nothing on the live site.

**The cause was layer order, not the particle values.** `.wm-veil` was stacked *on top of* `#particles-js`. Its vignette ramps to 88% of the page background from 40% outward, so it was painting over the nodes and links — worst exactly at the edges, which is where the network is most visible and where the content column isn't.

The veil exists to knock the brain plate back so body copy wins. Grading the plate and grading the network are two different jobs, and it was doing both. It now sits **under** the particles.

New stacking order:

```
plate (texture) → grid (structure) → veil (grade) → particles (network) → scan (sweep)
```

With that corrected the values could have stayed as they were, but they had been tuned against a layer that was being dimmed, so they're re-set for one that isn't:

| | before | after |
|---|---|---|
| nodes | 38 | 46 |
| node opacity | 0.55 (min 0.08) | 0.8 (min 0.3) |
| node size | 2.4 | 2.6 |
| link opacity | 0.24 | 0.4 |
| link width | 1 | 1.2 |
| brain plate opacity | 0.8 | 0.68 |

The `opacity_min` mattered more than it looks: at 0.08 the animation was fading individual nodes to almost nothing on every cycle, so the field flickered out rather than breathing.

The plate comes back a little so the network has something to read against. Between them the backdrop is about as legible overall as before, with the network rather than the photograph carrying it.

## Verified

Clean build on Hugo 0.160.1 and 0.140.2 (the deploying version). No console errors. Screenshotted at 1440px — nodes and links now read across the full viewport including the edges.

Branched off `main`, so this is independent of the portfolio work in #21 and can merge in either order.